### PR TITLE
BUG: Hotfix dark mode

### DIFF
--- a/smartessweb/src/public/styles/globals.css
+++ b/smartessweb/src/public/styles/globals.css
@@ -4,7 +4,7 @@
 
 :root {
   --background: #ffffff;
-  --foreground: #ffffff;
+  --foreground: #171717;
 }
 
 


### PR DESCRIPTION
Switching preferred mode to light to prevent a color palette change if the OS is on dark mode

