### PR TITLE
Task: prevent small screen use

### DIFF
--- a/smartessweb/frontend/src/app/sign-in/page.tsx
+++ b/smartessweb/frontend/src/app/sign-in/page.tsx
@@ -6,12 +6,16 @@ import { useRouter } from "next/navigation";
 import Toast, { showToastError, showToastSuccess } from "../components/Toast";
 import { signInApi } from "@/api/sign-in/sign-in";
 import Logo from "../../public/images/logo.png";
+import { IconButton } from "@mui/material";
+import Visibility from "@mui/icons-material/Visibility";
+import VisibilityOff from "@mui/icons-material/VisibilityOff";
 
 const SignInPage = () => {
   const router = useRouter();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [isSmallScreen, setIsSmallScreen] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
 
   const validateEmail = (email: string) => {
     const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -23,7 +27,6 @@ const SignInPage = () => {
       handleLogin(); // Trigger login on Enter key press
     }
   };
-
 
   useEffect(() => {
     const handleResize = () => {
@@ -127,13 +130,20 @@ const SignInPage = () => {
           </div>
           <div className="relative self-stretch">
             <input
-              type="password"
+              type={showPassword ? "text" : "password"}
               placeholder="Your Password"
               className="w-full self-stretch px-5 py-3 bg-[#898888]/20 rounded-[20px] text-[#266472] text-xl font-sequel-sans-regular focus:outline-none"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               onKeyDown={handleKeyDown}
             />
+            <IconButton
+              type="button"
+              onClick={() => setShowPassword(!showPassword)} // Toggle visibility
+              className="absolute right-3 top-1/2 transform -translate-y-1/2 text-[#266472]"
+            >
+              {showPassword ? <VisibilityOff /> : <Visibility />}
+            </IconButton>
           </div>
         </div>
 


### PR DESCRIPTION
### UPDATED LOGIN SCREEN FUNCTIONALITY

- added a condition that prevents users from logging in if the screen is too small (XS, iphones and mobile devices). This condition is only added on the login page, so that the users cant log in if their devices are too small
- users may log in on computers and then resize their window to whatever size they want once logged in, the condition is simply to discourage users from logging in on mobile devices since this website was not made for mobile device screen size use


- added a toggle for password visibility
- added functinoality to allow users to sign in using enter button on keyboard instead of only having to login by clicking btn



attempted to add tests but ran into too many issues with next js router mounting....

https://www.loom.com/share/cf15da54948b43ae80321bb3322b7ebc?sid=8bb7a102-e1e4-4d87-8a95-2efbb4d71c3c