### PR TITLE
BUGFIX--role-edit-form

### DIFF
--- a/smartessweb/frontend/src/app/components/ManageUsersComponents/RoleEditForm.tsx
+++ b/smartessweb/frontend/src/app/components/ManageUsersComponents/RoleEditForm.tsx
@@ -1,4 +1,3 @@
-// RoleEditForm.tsx
 import React, { useState } from "react";
 
 interface RoleEditFormProps {
@@ -7,7 +6,11 @@ interface RoleEditFormProps {
   onSave: () => void; // Add a callback for Save action
 }
 
-function RoleEditForm({ currentRole, onRoleChange }: RoleEditFormProps) {
+function RoleEditForm({
+  currentRole,
+  onRoleChange,
+  onSave,
+}: RoleEditFormProps) {
   const [selectedRole, setSelectedRole] = useState<
     "admin" | "basic" | "master"
   >(currentRole);
@@ -16,6 +19,7 @@ function RoleEditForm({ currentRole, onRoleChange }: RoleEditFormProps) {
     const newRole = event.target.value as "admin" | "basic" | "master";
     setSelectedRole(newRole);
     onRoleChange(newRole);
+    onSave(); // Trigger save and close form on role change
   };
 
   return (


### PR DESCRIPTION
Previous behavior: Once pressing the edit role button and changing the role, the form stays open even if you close the user info modal and reopen it. It only closes if you restart the page

Fixed behavior: After selecting a new role, it updates the role displayed in the user info modal and closes the form.

