### PR TITLE
Unit list page styling changes

### DIFF
--- a/smartessweb/frontend/src/app/components/UnitListComponent.tsx
+++ b/smartessweb/frontend/src/app/components/UnitListComponent.tsx
@@ -46,11 +46,11 @@ const UnitComponent = ({
 
   return (
     <div className="unit-container max-w-fit sm:max-w-full mx-auto">
-      <div className="bg-[#fff] rounded-[7px] w-full mt-4 mb-4 shadow-xl">
-        <div className="text-[#4B7D8D] font-sequel-sans-black text-center text-2xl p-2">
+      <div className="bg-[#fff] rounded-[7px] w-full mb-2">
+        <div className="text-[#4B7D8D] text-xxl text-center text-2xl pt-8">
           {projectAddress}
         </div>
-        <div className="text-[#729987] text-xl font-sequel-sans-black text-center p-2">
+        <div className="text-[#729987] text-xl text-center p-2 ">
           Unit {unit.unitNumber}
         </div>
 
@@ -76,7 +76,7 @@ const UnitComponent = ({
         <div className="flex justify-center p-6">
           <div>
             <button
-              className="bg-[#4b7d8d] w-40 h-12 rounded-[10px] text-white text-md font-sequel-sans-black hover:bg-[#1f505e] transition duration-300"
+              className="bg-[#266472] rounded-md hover:bg-[#1f505e] w-40 h-10 text-white text-md hover:bg-[#1f505e] transition duration-300"
               onClick={handleViewUnit}
             >
               View Unit


### PR DESCRIPTION
Previously: 
<img width="1593" alt="Screenshot 2024-12-26 at 7 15 41 PM" src="https://github.com/user-attachments/assets/84332e6f-1004-4ce1-9382-600f3b9a994f" />


Changes to layout for more uniformity across unit list and individual unit page. #286

<img width="1616" alt="Screenshot 2024-12-26 at 7 14 41 PM" src="https://github.com/user-attachments/assets/2f732de6-fd0e-4d43-9888-5b8532920a81" />

<img width="1607" alt="Screenshot 2024-12-26 at 7 16 11 PM" src="https://github.com/user-attachments/assets/59a483dc-9ad9-432f-9354-619fda11407f" />

