### PR TITLE
TASK- Remove delete project modal

### DIFF
--- a/smartessweb/frontend/src/app/components/ManageUsersComponents/UserInfoModal.tsx
+++ b/smartessweb/frontend/src/app/components/ManageUsersComponents/UserInfoModal.tsx
@@ -40,7 +40,6 @@ function UserInfoModal({
   const [addresses, setAddresses] = useState<string[]>(initialAddresses);
   const [isEditingRole, setIsEditingRole] = useState(false);
   const [isDeletePopupOpen, setDeletePopupOpen] = useState(false);
-  const [addressToDelete, setAddressToDelete] = useState<string | null>(null);
   const [isProjectMenuOpen, setProjectMenuOpen] = useState(false);
   const [isUserDeletion, setIsUserDeletion] = useState(false);
   const [orgProjects, setOrgProjects] = useState<Project[]>([]);
@@ -368,7 +367,6 @@ function UserInfoModal({
 
           {isDeletePopupOpen && (
             <DeleteConfirmationPopup
-              addressToDelete={addressToDelete}
               userName={userName}
               onConfirm={handleConfirmDelete}
               isUserDeletion={isUserDeletion}


### PR DESCRIPTION
1. Removed the delete modal when deleting a project and switched the functionality to the trash for UI followed by the save button for state change

2. Changed the logic of delete user function to only include the user deletion 

3. Changed the delete button in the main edit modal to "Delete User" and fixed the spacing of the buttons

