### PR TITLE
fixed spelling mistake in success toast

### DIFF
--- a/smartessweb/frontend/src/app/components/ManageUsersComponents/AddUserForm.tsx
+++ b/smartessweb/frontend/src/app/components/ManageUsersComponents/AddUserForm.tsx
@@ -84,7 +84,7 @@ export default function AddUserModal({ isOpen, onClose }: AddUserProps) {
 
     resetForm();
 
-    showToastSuccess("Invitiation Sent!");
+    showToastSuccess("Invitation Sent!");
   };
 
   if (!isOpen) return null;


### PR DESCRIPTION
Fixed typo in success toast
Previous: invitiation
Changed to: Invitation 
![image](https://github.com/user-attachments/assets/00acd2be-27b7-470a-aed7-a24db6f714f2)
