### PR TITLE
US8.1-BUG - Wrong value for total camera count

### DIFF
--- a/smartessweb/frontend/src/app/dashboard/surveillance/page.tsx
+++ b/smartessweb/frontend/src/app/dashboard/surveillance/page.tsx
@@ -143,7 +143,7 @@ const fetchData = async () => {
           <div className="flex justify-center px-4">
             <div className="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-3 gap-4 w-full max-w-[100%] mt-2">
               <SurveillanceWidget
-                count={filteredUnitsByProject.length}
+                count={allUnits.length}
                 label="Total Cameras"
                 backgroundColor="bg-[#56798d]"
                 onClick={handleClickTotal}


### PR DESCRIPTION
Choose allUnits length rather than the filtered units for displaying the total camera count. The previous version would change the count depending on the search results