### PR TITLE
HUB7-T6 Alert yaml and different alert types mockhub

### DIFF
--- a/go/cmd/mockhub/main.go
+++ b/go/cmd/mockhub/main.go
@@ -65,9 +65,9 @@ func GenerateEventMessage() ha.WebhookMessage {
 		panic(err)
 	}
 
-	rand.Seed(time.Now().UnixNano())
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 
-	randomEvent := eventsWrapper.Events[rand.Intn(len(eventsWrapper.Events))]
+	randomEvent := eventsWrapper.Events[r.Intn(len(eventsWrapper.Events))]
 
 	//override TimeFired with the current time
 	randomEvent.Event.TimeFired = time.Now().Format(time.RFC3339)


### PR DESCRIPTION
Encapsulate mock events into yaml, randomly generated to match an alert type
Fix alert timestamp to represent current time instead of hardcoded
Add events to simulate different alert types:

- AlertTypeLight       = "Light"
- AlertTypeSensor      = "Sensor"
- AlertTypeClimate     = "Climate"
- AlertTypeBatteryLow  = "BatteryLow"
- AlertTypeMotion      = "Motion"
- AlertTypeDoorOpen    = "DoorOpen"
- AlertTypeSmoke       = "Smoke"
- AlertTypeWater       = "Water"
- AlertTypeTemperature = "Temperature"
- AlertTypeUnknown     = "Unknown"

Closes #662