### PR TITLE
HUB7-T6 Mockhub alert yaml and different alert types

### DIFF
--- a/go/cmd/mockhub/config/mock-events.yaml
+++ b/go/cmd/mockhub/config/mock-events.yaml
@@ -1,0 +1,717 @@
+events:
+  - id: 1
+    type: "state_changed"
+    event:
+      event_type: "state_changed"
+      data:
+        entity_id: "light.hue_go_2"
+        old_state:
+          entity_id: "light.hue_go_2"
+          state: "off"
+          attributes:
+            friendly_name: "Kitchen Light"
+            off_brightness: null
+            off_with_transition: false
+            supported_color_modes:
+              - "onoff"
+            supported_features: 8
+          last_changed: "2024-11-26T22:33:57.907198Z"
+          last_updated: "2024-11-26T22:33:57.907198Z"
+          context:
+            id: "01JDN9R843GN161T321VYY0FJ7"
+            parent_id: ""
+            user_id: "288a21978a6d496b90aefec65844c6ec"
+        new_state:
+          entity_id: "light.hue_go_2"
+          state: "on"
+          attributes:
+            friendly_name: "Kitchen Light"
+            off_brightness: null
+            off_with_transition: false
+            supported_color_modes:
+              - "onoff"
+            supported_features: 8
+            rgb_color:
+              - 238
+              - 254
+              - 255
+          last_changed: "2024-11-26T22:33:57.907198Z"
+          last_updated: "2024-11-26T22:33:57.907198Z"
+          context:
+            id: "01JDN9R843GN161T321VYY0FJ7"
+            parent_id: ""
+            user_id: "288a21978a6d496b90aefec65844c6ec"
+      origin: "LOCAL"
+      time_fired: "CURRENT_TIME"
+      context:
+        id: "01JDN9R843GN161T321VYY0FJ7"
+        parent_id: ""
+        user_id: "288a21978a6d496b90aefec65844c6ec"
+
+#more events to imitate real alerts
+#alerts parsed off rgb values
+
+#alert type sensor
+  - id: 2
+    type: "state_changed"
+    event:
+      event_type: "state_changed"
+      data:
+        entity_id: "light.hue_go_2"
+        old_state:
+          entity_id: "light.hue_go_2"
+          state: "off"
+          attributes:
+            friendly_name: "Kitchen Light"
+            off_brightness: null
+            off_with_transition: false
+            supported_color_modes:
+              - "onoff"
+            supported_features: 8
+          last_changed: "2024-11-26T22:33:57.907198Z"
+          last_updated: "2024-11-26T22:33:57.907198Z"
+          context:
+            id: "01JDN9R843GN161T321VYY0FJ7"
+            parent_id: ""
+            user_id: "288a21978a6d496b90aefec65844c6ec"
+        new_state:
+          entity_id: "light.hue_go_2"
+          state: "on"
+          attributes:
+            friendly_name: "Kitchen Light"
+            off_brightness: null
+            off_with_transition: false
+            supported_color_modes:
+              - "onoff"
+            supported_features: 8
+            rgb_color:
+              - 255
+              - 42
+              - 225
+          last_changed: "2024-11-26T22:33:57.907198Z"
+          last_updated: "2024-11-26T22:33:57.907198Z"
+          context:
+            id: "01JDN9R843GN161T321VYY0FJ7"
+            parent_id: ""
+            user_id: "288a21978a6d496b90aefec65844c6ec"
+      origin: "LOCAL"
+      time_fired: "CURRENT_TIME"
+      context:
+        id: "01JDN9R843GN161T321VYY0FJ7"
+        parent_id: ""
+        user_id: "288a21978a6d496b90aefec65844c6ec"
+  
+#alert type climate
+  - id: 3
+    type: "state_changed"
+    event:
+      event_type: "state_changed"
+      data:
+        entity_id: "light.hue_go_2"
+        old_state:
+          entity_id: "light.hue_go_2"
+          state: "off"
+          attributes:
+            friendly_name: "Kitchen Light"
+            off_brightness: null
+            off_with_transition: false
+            supported_color_modes:
+              - "onoff"
+            supported_features: 8
+          last_changed: "2024-11-26T22:33:57.907198Z"
+          last_updated: "2024-11-26T22:33:57.907198Z"
+          context:
+            id: "01JDN9R843GN161T321VYY0FJ7"
+            parent_id: ""
+            user_id: "288a21978a6d496b90aefec65844c6ec"
+        new_state:
+          entity_id: "light.hue_go_2"
+          state: "on"
+          attributes:
+            friendly_name: "Kitchen Light"
+            off_brightness: null
+            off_with_transition: false
+            supported_color_modes:
+              - "onoff"
+            supported_features: 8
+            rgb_color:
+              - 123
+              - 255
+              - 66
+          last_changed: "2024-11-26T22:33:57.907198Z"
+          last_updated: "2024-11-26T22:33:57.907198Z"
+          context:
+            id: "01JDN9R843GN161T321VYY0FJ7"
+            parent_id: ""
+            user_id: "288a21978a6d496b90aefec65844c6ec"
+      origin: "LOCAL"
+      time_fired: "CURRENT_TIME"
+      context:
+        id: "01JDN9R843GN161T321VYY0FJ7"
+        parent_id: ""
+        user_id: "288a21978a6d496b90aefec65844c6ec"
+
+#alert type battery low
+  - id: 4
+    type: "state_changed"
+    event:
+      event_type: "state_changed"
+      data:
+        entity_id: "light.hue_go_2"
+        old_state:
+          entity_id: "light.hue_go_2"
+          state: "off"
+          attributes:
+            friendly_name: "Kitchen Light"
+            off_brightness: null
+            off_with_transition: false
+            supported_color_modes:
+              - "onoff"
+            supported_features: 8
+          last_changed: "2024-11-26T22:33:57.907198Z"
+          last_updated: "2024-11-26T22:33:57.907198Z"
+          context:
+            id: "01JDN9R843GN161T321VYY0FJ7"
+            parent_id: ""
+            user_id: "288a21978a6d496b90aefec65844c6ec"
+        new_state:
+          entity_id: "light.hue_go_2"
+          state: "on"
+          attributes:
+            friendly_name: "Kitchen Light"
+            off_brightness: null
+            off_with_transition: false
+            supported_color_modes:
+              - "onoff"
+            supported_features: 8
+            rgb_color:
+              - 255
+              - 72
+              - 15
+          last_changed: "2024-11-26T22:33:57.907198Z"
+          last_updated: "2024-11-26T22:33:57.907198Z"
+          context:
+            id: "01JDN9R843GN161T321VYY0FJ7"
+            parent_id: ""
+            user_id: "288a21978a6d496b90aefec65844c6ec"
+      origin: "LOCAL"
+      time_fired: "CURRENT_TIME"
+      context:
+        id: "01JDN9R843GN161T321VYY0FJ7"
+        parent_id: ""
+        user_id: "288a21978a6d496b90aefec65844c6ec"
+
+#alert type door open
+  - id: 5
+    type: "state_changed"
+    event:
+      event_type: "state_changed"
+      data:
+        entity_id: "light.hue_go_2"
+        old_state:
+          entity_id: "light.hue_go_2"
+          state: "off"
+          attributes:
+            friendly_name: "Kitchen Light"
+            off_brightness: null
+            off_with_transition: false
+            supported_color_modes:
+              - "onoff"
+            supported_features: 8
+          last_changed: "2024-11-26T22:33:57.907198Z"
+          last_updated: "2024-11-26T22:33:57.907198Z"
+          context:
+            id: "01JDN9R843GN161T321VYY0FJ7"
+            parent_id: ""
+            user_id: "288a21978a6d496b90aefec65844c6ec"
+        new_state:
+          entity_id: "light.hue_go_2"
+          state: "on"
+          attributes:
+            friendly_name: "Kitchen Light"
+            off_brightness: null
+            off_with_transition: false
+            supported_color_modes:
+              - "onoff"
+            supported_features: 8
+            rgb_color:
+              - 105
+              - 9
+              - 255
+          last_changed: "2024-11-26T22:33:57.907198Z"
+          last_updated: "2024-11-26T22:33:57.907198Z"
+          context:
+            id: "01JDN9R843GN161T321VYY0FJ7"
+            parent_id: ""
+            user_id: "288a21978a6d496b90aefec65844c6ec"
+      origin: "LOCAL"
+      time_fired: "CURRENT_TIME"
+      context:
+        id: "01JDN9R843GN161T321VYY0FJ7"
+        parent_id: ""
+        user_id: "288a21978a6d496b90aefec65844c6ec"
+
+#alert type smoke
+  - id: 6
+    type: "state_changed"
+    event:
+      event_type: "state_changed"
+      data:
+        entity_id: "light.hue_go_2"
+        old_state:
+          entity_id: "light.hue_go_2"
+          state: "off"
+          attributes:
+            friendly_name: "Kitchen Light"
+            off_brightness: null
+            off_with_transition: false
+            supported_color_modes:
+              - "onoff"
+            supported_features: 8
+          last_changed: "2024-11-26T22:33:57.907198Z"
+          last_updated: "2024-11-26T22:33:57.907198Z"
+          context:
+            id: "01JDN9R843GN161T321VYY0FJ7"
+            parent_id: ""
+            user_id: "288a21978a6d496b90aefec65844c6ec"
+        new_state:
+          entity_id: "light.hue_go_2"
+          state: "on"
+          attributes:
+            friendly_name: "Kitchen Light"
+            off_brightness: null
+            off_with_transition: false
+            supported_color_modes:
+              - "onoff"
+            supported_features: 8
+            rgb_color:
+              - 255
+              - 51
+              - 0
+          last_changed: "2024-11-26T22:33:57.907198Z"
+          last_updated: "2024-11-26T22:33:57.907198Z"
+          context:
+            id: "01JDN9R843GN161T321VYY0FJ7"
+            parent_id: ""
+            user_id: "288a21978a6d496b90aefec65844c6ec"
+      origin: "LOCAL"
+      time_fired: "CURRENT_TIME"
+      context:
+        id: "01JDN9R843GN161T321VYY0FJ7"
+        parent_id: ""
+        user_id: "288a21978a6d496b90aefec65844c6ec"
+
+#alert type water
+  - id: 7
+    type: "state_changed"
+    event:
+      event_type: "state_changed"
+      data:
+        entity_id: "light.hue_go_2"
+        old_state:
+          entity_id: "light.hue_go_2"
+          state: "off"
+          attributes:
+            friendly_name: "Kitchen Light"
+            off_brightness: null
+            off_with_transition: false
+            supported_color_modes:
+              - "onoff"
+            supported_features: 8
+          last_changed: "2024-11-26T22:33:57.907198Z"
+          last_updated: "2024-11-26T22:33:57.907198Z"
+          context:
+            id: "01JDN9R843GN161T321VYY0FJ7"
+            parent_id: ""
+            user_id: "288a21978a6d496b90aefec65844c6ec"
+        new_state:
+          entity_id: "light.hue_go_2"
+          state: "on"
+          attributes:
+            friendly_name: "Kitchen Light"
+            off_brightness: null
+            off_with_transition: false
+            supported_color_modes:
+              - "onoff"
+            supported_features: 8
+            rgb_color:
+              - 61
+              - 134
+              - 255
+          last_changed: "2024-11-26T22:33:57.907198Z"
+          last_updated: "2024-11-26T22:33:57.907198Z"
+          context:
+            id: "01JDN9R843GN161T321VYY0FJ7"
+            parent_id: ""
+            user_id: "288a21978a6d496b90aefec65844c6ec"
+      origin: "LOCAL"
+      time_fired: "CURRENT_TIME"
+      context:
+        id: "01JDN9R843GN161T321VYY0FJ7"
+        parent_id: ""
+        user_id: "288a21978a6d496b90aefec65844c6ec"
+
+# alert type temperature
+  - id: 8
+    type: "state_changed"
+    event:
+      event_type: "state_changed"
+      data:
+        entity_id: "light.hue_go_2"
+        old_state:
+          entity_id: "light.hue_go_2"
+          state: "off"
+          attributes:
+            friendly_name: "Kitchen Light"
+            off_brightness: null
+            off_with_transition: false
+            supported_color_modes:
+              - "onoff"
+            supported_features: 8
+          last_changed: "2024-11-26T22:33:57.907198Z"
+          last_updated: "2024-11-26T22:33:57.907198Z"
+          context:
+            id: "01JDN9R843GN161T321VYY0FJ7"
+            parent_id: ""
+            user_id: "288a21978a6d496b90aefec65844c6ec"
+        new_state:
+          entity_id: "light.hue_go_2"
+          state: "on"
+          attributes:
+            friendly_name: "Kitchen Light"
+            off_brightness: null
+            off_with_transition: false
+            supported_color_modes:
+              - "onoff"
+            supported_features: 8
+            rgb_color:
+              - 255
+              - 196
+              - 103
+          last_changed: "2024-11-26T22:33:57.907198Z"
+          last_updated: "2024-11-26T22:33:57.907198Z"
+          context:
+            id: "01JDN9R843GN161T321VYY0FJ7"
+            parent_id: ""
+            user_id: "288a21978a6d496b90aefec65844c6ec"
+      origin: "LOCAL"
+      time_fired: "CURRENT_TIME"
+      context:
+        id: "01JDN9R843GN161T321VYY0FJ7"
+        parent_id: ""
+        user_id: "288a21978a6d496b90aefec65844c6ec"
+
+    # - id: 1
+  #   type: "state_changed"
+  #   event:
+  #     event_type: "state_changed"
+  #     data:
+  #       entity_id: "climate.sinope_technologies_th1124zb_g2_thermostat"
+  #       old_state: {}
+  #       new_state:
+  #         entity_id: "climate.sinope_technologies_th1124zb_g2_thermostat"
+  #         state: "heat"
+  #         attributes:
+  #           current_temperature: 20.5
+  #           friendly_name: "Master Bedroom Thermostat"
+  #           hvac_action: "idle"
+  #           hvac_modes:
+  #             - "off"
+  #             - "heat"
+  #           max_temp: 30
+  #           min_temp: 5
+  #           occupancy: 1
+  #           occupied_cooling_setpoint: 2600
+  #           occupied_heating_setpoint: 1950
+  #           pi_heating_demand: 0
+  #           preset_mode: "none"
+  #           preset_modes:
+  #             - "away"
+  #             - "none"
+  #           supported_features: 17
+  #           system_mode: "[<SystemMode.Heat: 4>]/heat"
+  #           temperature: 19.5
+  #           unoccupied_heating_setpoint: 1500
+  #         last_changed: "2024-11-14T14:26:12.795069Z"
+  #         last_updated: "2024-11-26T22:34:20.807774Z"
+  #         context:
+  #           id: "01JDN9RZ6HMT9PEZAMT3DHY2MB"
+  #           parent_id: ""
+  #           user_id: "2cfced4b8a794ab59da3543e6feebdd7"
+  #     origin: "LOCAL"
+  #     time_fired: "CURRENT_TIME"
+  #     context:
+  #       id: "01JDN9RZ6HMT9PEZAMT3DHY2MB"
+  #       parent_id: ""
+  #       user_id: "2cfced4b8a794ab59da3543e6feebdd7"
+
+  # - id: 3
+  #   type: "state_changed"
+  #   event:
+  #     event_type: "state_changed"
+  #     data:
+  #       entity_id: "sensor.sinope_technologies_th1123zb_g2_temperature"
+  #       old_state: {}
+  #       new_state:
+  #         entity_id: "sensor.sinope_technologies_th1123zb_g2_temperature"
+  #         state: "27.0"
+  #         attributes:
+  #           device_class: "temperature"
+  #           friendly_name: "Sinope Technologies TH1123ZB-G2 Temperature"
+  #           state_class: "measurement"
+  #           unit_of_measurement: "°C"
+  #         last_changed: "2024-11-26T22:34:43.172305Z"
+  #         last_updated: "2024-11-26T22:34:43.172305Z"
+  #         context:
+  #           id: "01JDN9SN345HZCFMAJJG769V8K"
+  #           parent_id: ""
+  #           user_id: ""
+  #     origin: "LOCAL"
+  #     time_fired: "CURRENT_TIME"
+  #     context:
+  #       id: "01JDN9SN345HZCFMAJJG769V8K"
+  #       parent_id: ""
+  #       user_id: ""
+
+  # - id: 4
+  #   type: "Light Warning"
+  #   event:
+  #     event_type: "state_changed"
+  #     data:
+  #       entity_id: "light.lumi_lumi_switch_b1laus01_light_3"
+  #       old_state:
+  #         entity_id: "light.lumi_lumi_switch_b1laus01_light_3"
+  #         state: "on"
+  #         attributes:
+  #           friendly_name: "Kitchen Light"
+  #           off_brightness: null
+  #           off_with_transition: false
+  #           supported_color_modes:
+  #             - "onoff"
+  #           supported_features: 8
+  #         last_changed: "2024-11-26T22:33:57.907198Z"
+  #         last_updated: "2024-11-26T22:33:57.907198Z"
+  #         context:
+  #           id: "01JDN9R843GN161T321VYY0FJ7"
+  #           parent_id: ""
+  #           user_id: "288a21978a6d496b90aefec65844c6ec"
+  #       new_state:
+  #         entity_id: "light.lumi_lumi_switch_b1laus01_light_3"
+  #         state: "on"
+  #         attributes:
+  #           friendly_name: "Kitchen Light"
+  #           off_brightness: null
+  #           off_with_transition: false
+  #           supported_color_modes:
+  #             - "onoff"
+  #           supported_features: 12
+  #         last_changed: "2024-11-26T22:33:57.907198Z"
+  #         last_updated: "2024-11-26T22:33:57.907198Z"
+  #         context:
+  #           id: "01JDN9R843GN161T321VYY0FJ7"
+  #           parent_id: ""
+  #           user_id: "288a21978a6d496b90aefec65844c6ec"
+  #     origin: "LOCAL"
+  #     time_fired: "CURRENT_TIME"
+  #     context:
+  #       id: "01JDN9R843GN161T321VYY0FJ7"
+  #       parent_id: ""
+  #       user_id: "288a21978a6d496b90aefec65844c6ec"
+
+  # - id: 5
+  #   type: "Light Information"
+  #   event:
+  #     event_type: "state_changed"
+  #     data:
+  #       entity_id: "light.lumi_lumi_switch_b1laus01_light_3"
+  #       old_state: {}
+  #       new_state:
+  #         entity_id: "light.lumi_lumi_switch_b1laus01_light_3"
+  #         state: "on"
+  #         attributes:
+  #           friendly_name: "Kitchen Light"
+  #           off_brightness: null
+  #           off_with_transition: false
+  #           supported_color_modes:
+  #             - "onoff"
+  #           supported_features: 12
+  #         last_changed: "2024-11-26T22:33:57.907198Z"
+  #         last_updated: "2024-11-26T22:33:57.907198Z"
+  #         context:
+  #           id: "01JDN9R843GN161T321VYY0FJ7"
+  #           parent_id: ""
+  #           user_id: "288a21978a6d496b90aefec65844c6ec"
+  #     origin: "LOCAL"
+  #     time_fired: "CURRENT_TIME"
+  #     context:
+  #       id: "01JDN9R843GN161T321VYY0FJ7"
+  #       parent_id: ""
+  #       user_id: "288a21978a6d496b90aefec65844c6ec"
+
+  # - id: 6
+  #   type: "state_changed"
+  #   event:
+  #     event_type: "state_changed"
+  #     data:
+  #       entity_id: "battery.sinope_technologies_th1123zb_g2_temperature"
+  #       old_state: {}
+  #       new_state:
+  #         entity_id: "battery.sinope_technologies_th1123zb_g2_temperature"
+  #         state: "21.3"
+  #         attributes:
+  #           device_class: "temperature"
+  #           friendly_name: "Sinope Technologies TH1123ZB-G2 Temperature"
+  #           state_class: "measurement"
+  #           unit_of_measurement: "°C"
+  #         last_changed: "2024-11-26T22:34:43.172305Z"
+  #         last_updated: "2024-11-26T22:34:43.172305Z"
+  #         context:
+  #           id: "01JDN9SN345HZCFMAJJG769V8K"
+  #           parent_id: ""
+  #           user_id: ""
+  #     origin: "LOCAL"
+  #     time_fired: "CURRENT_TIME"
+  #     context:
+  #       id: "01JDN9SN345HZCFMAJJG769V8K"
+  #       parent_id: ""
+  #       user_id: ""
+
+  # - id: 7
+  #   type: "state_changed"
+  #   event:
+  #     event_type: "state_changed"
+  #     data:
+  #       entity_id: "motion.sinope_technologies_th1123zb_g2_temperature"
+  #       old_state: {}
+  #       new_state:
+  #         entity_id: "motion.sinope_technologies_th1123zb_g2_temperature"
+  #         state: "21.3"
+  #         attributes:
+  #           device_class: "temperature"
+  #           friendly_name: "Sinope Technologies TH1123ZB-G2 Temperature"
+  #           state_class: "measurement"
+  #           unit_of_measurement: "°C"
+  #         last_changed: "2024-11-26T22:34:43.172305Z"
+  #         last_updated: "2024-11-26T22:34:43.172305Z"
+  #         context:
+  #           id: "01JDN9SN345HZCFMAJJG769V8K"
+  #           parent_id: ""
+  #           user_id: ""
+  #     origin: "LOCAL"
+  #     time_fired: "CURRENT_TIME"
+  #     context:
+  #       id: "01JDN9SN345HZCFMAJJG769V8K"
+  #       parent_id: ""
+  #       user_id: ""
+
+  # - id: 8
+  #   type: "state_changed"
+  #   event:
+  #     event_type: "state_changed"
+  #     data:
+  #       entity_id: "door.sinope_technologies_th1123zb_g2_temperature"
+  #       old_state: {}
+  #       new_state:
+  #         entity_id: "door.sinope_technologies_th1123zb_g2_temperature"
+  #         state: "21.3"
+  #         attributes:
+  #           device_class: "temperature"
+  #           friendly_name: "Sinope Technologies TH1123ZB-G2 Temperature"
+  #           state_class: "measurement"
+  #           unit_of_measurement: "°C"
+  #         last_changed: "2024-11-26T22:34:43.172305Z"
+  #         last_updated: "2024-11-26T22:34:43.172305Z"
+  #         context:
+  #           id: "01JDN9SN345HZCFMAJJG769V8K"
+  #           parent_id: ""
+  #           user_id: ""
+  #     origin: "LOCAL"
+  #     time_fired: "CURRENT_TIME"
+  #     context:
+  #       id: "01JDN9SN345HZCFMAJJG769V8K"
+  #       parent_id: ""
+  #       user_id: ""
+
+  # - id: 9
+  #   type: "state_changed"
+  #   event:
+  #     event_type: "state_changed"
+  #     data:
+  #       entity_id: "smoke.sinope_technologies_th1123zb_g2_temperature"
+  #       old_state: {}
+  #       new_state:
+  #         entity_id: "smoke.sinope_technologies_th1123zb_g2_temperature"
+  #         state: "21.3"
+  #         attributes:
+  #           device_class: "temperature"
+  #           friendly_name: "Sinope Technologies TH1123ZB-G2 Temperature"
+  #           state_class: "measurement"
+  #           unit_of_measurement: "°C"
+  #         last_changed: "2024-11-26T22:34:43.172305Z"
+  #         last_updated: "2024-11-26T22:34:43.172305Z"
+  #         context:
+  #           id: "01JDN9SN345HZCFMAJJG769V8K"
+  #           parent_id: ""
+  #           user_id: ""
+  #     origin: "LOCAL"
+  #     time_fired: "CURRENT_TIME"
+  #     context:
+  #       id: "01JDN9SN345HZCFMAJJG769V8K"
+  #       parent_id: ""
+  #       user_id: ""
+
+  # - id: 10
+  #   type: "state_changed"
+  #   event:
+  #     event_type: "state_changed"
+  #     data:
+  #       entity_id: "water.sinope_technologies_th1123zb_g2_temperature"
+  #       old_state: {}
+  #       new_state:
+  #         entity_id: "water.sinope_technologies_th1123zb_g2_temperature"
+  #         state: "21.3"
+  #         attributes:
+  #           device_class: "temperature"
+  #           friendly_name: "Sinope Technologies TH1123ZB-G2 Temperature"
+  #           state_class: "measurement"
+  #           unit_of_measurement: "°C"
+  #         last_changed: "2024-11-26T22:34:43.172305Z"
+  #         last_updated: "2024-11-26T22:34:43.172305Z"
+  #         context:
+  #           id: "01JDN9SN345HZCFMAJJG769V8K"
+  #           parent_id: ""
+  #           user_id: ""
+  #     origin: "LOCAL"
+  #     time_fired: "CURRENT_TIME"
+  #     context:
+  #       id: "01JDN9SN345HZCFMAJJG769V8K"
+  #       parent_id: ""
+  #       user_id: ""
+
+  # - id: 11
+  #   type: "state_changed"
+  #   event:
+  #     event_type: "state_changed"
+  #     data:
+  #       entity_id: "temperature.sinope_technologies_th1123zb_g2_temperature"
+  #       old_state: {}
+  #       new_state:
+  #         entity_id: "temperature.sinope_technologies_th1123zb_g2_temperature"
+  #         state: "21.3"
+  #         attributes:
+  #           device_class: "temperature"
+  #           friendly_name: "Sinope Technologies TH1123ZB-G2 Temperature"
+  #           state_class: "measurement"
+  #           unit_of_measurement: "°C"
+  #         last_changed: "2024-11-26T22:34:43.172305Z"
+  #         last_updated: "2024-11-26T22:34:43.172305Z"
+  #         context:
+  #           id: "01JDN9SN345HZCFMAJJG769V8K"
+  #           parent_id: ""
+  #           user_id: ""
+  #     origin: "LOCAL"
+  #     time_fired: "CURRENT_TIME"
+  #     context:
+  #       id: "01JDN9SN345HZCFMAJJG769V8K"
+  #       parent_id: ""
+  #       user_id: ""

--- a/go/cmd/mockhub/docker-compose.yml
+++ b/go/cmd/mockhub/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - "8765:8765"
     volumes:
       - ./data:/tmp/data
+      - ./config:/app/config/mockhub
     networks:
       - smartess_network
   mock_camera:

--- a/go/cmd/mockhub/main.go
+++ b/go/cmd/mockhub/main.go
@@ -1,14 +1,16 @@
 package main
 
 import (
-	"Smartess/go/common/structures"
 	"Smartess/go/hub/ha"
 	"encoding/json"
 	"log"
+	"math/rand"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/gorilla/websocket"
+	"gopkg.in/yaml.v3"
 )
 
 var upgrader = websocket.Upgrader{
@@ -45,464 +47,42 @@ func main() {
 	log.Fatal(http.ListenAndServe(":8765", nil))
 }
 
+type EventsWrapper struct {
+	Events []ha.WebhookMessage `yaml:"events"`
+}
+
 func GenerateEventMessage() ha.WebhookMessage {
-	//rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-	//eventID := rng.Intn(11) + 1
-	eventID := 2
-	var event ha.WebhookMessage
 
-	switch eventID {
-	case 1:
-		event = ha.WebhookMessage{
-			ID:   1,
-			Type: "state_changed",
-			Event: structures.EventDetails{
-				EventType: "state_changed",
-				Data: structures.EventData{
-					EntityID: "climate.sinope_technologies_th1124zb_g2_thermostat",
-					OldState: structures.State{},
-					NewState: structures.State{
-						EntityID: "climate.sinope_technologies_th1124zb_g2_thermostat",
-						State:    "heat",
-						Attributes: map[string]interface{}{
-							"current_temperature":         20.5,
-							"friendly_name":               "Master Bedroom Thermostat",
-							"hvac_action":                 "idle",
-							"hvac_modes":                  []string{"off", "heat"},
-							"max_temp":                    30,
-							"min_temp":                    5,
-							"occupancy":                   1,
-							"occupied_cooling_setpoint":   2600,
-							"occupied_heating_setpoint":   1950,
-							"pi_heating_demand":           0,
-							"preset_mode":                 "none",
-							"preset_modes":                []string{"away", "none"},
-							"supported_features":          17,
-							"system_mode":                 "[<SystemMode.Heat: 4>]/heat",
-							"temperature":                 19.5,
-							"unoccupied_heating_setpoint": 1500,
-						},
-						LastChanged: time.Date(2024, 11, 14, 14, 26, 12, 795069000, time.UTC),
-						LastUpdated: time.Date(2024, 11, 26, 22, 34, 20, 807774000, time.UTC),
-						Context: structures.EventContext{
-							ID:       "01JDN9RZ6HMT9PEZAMT3DHY2MB",
-							ParentID: "",
-							UserID:   "2cfced4b8a794ab59da3543e6feebdd7",
-						},
-					},
-				},
-				Origin:    "LOCAL",
-				TimeFired: time.Now().Format(time.RFC3339),
-				Context: structures.EventContext{
-					ID:       "01JDN9RZ6HMT9PEZAMT3DHY2MB",
-					ParentID: "",
-					UserID:   "2cfced4b8a794ab59da3543e6feebdd7",
-				},
-			},
-		}
-
-	case 2:
-		event = ha.WebhookMessage{
-			ID:   2,
-			Type: "state_changed",
-			Event: structures.EventDetails{
-				EventType: "state_changed",
-				Data: structures.EventData{
-					EntityID: "light.hue_go_2",
-					OldState: structures.State{
-						EntityID: "light.hue_go_2",
-						State:    "off",
-						Attributes: map[string]interface{}{
-							"friendly_name":         "Kitchen Light",
-							"off_brightness":        nil,
-							"off_with_transition":   false,
-							"supported_color_modes": []string{"onoff"},
-							"supported_features":    8,
-						},
-						LastChanged: time.Date(2024, 11, 26, 22, 33, 57, 907198000, time.UTC),
-						LastUpdated: time.Date(2024, 11, 26, 22, 33, 57, 907198000, time.UTC),
-						Context: structures.EventContext{
-							ID:       "01JDN9R843GN161T321VYY0FJ7",
-							ParentID: "",
-							UserID:   "288a21978a6d496b90aefec65844c6ec",
-						},
-					},
-					NewState: structures.State{
-						EntityID: "light.hue_go_2",
-						State:    "on",
-						Attributes: map[string]interface{}{
-							"friendly_name":         "Kitchen Light",
-							"off_brightness":        nil,
-							"off_with_transition":   false,
-							"supported_color_modes": []string{"onoff"},
-							"supported_features":    8,
-							"rgb_color":             []int{238, 254, 255},
-						},
-						LastChanged: time.Date(2024, 11, 26, 22, 33, 57, 907198000, time.UTC),
-						LastUpdated: time.Date(2024, 11, 26, 22, 33, 57, 907198000, time.UTC),
-						Context: structures.EventContext{
-							ID:       "01JDN9R843GN161T321VYY0FJ7",
-							ParentID: "",
-							UserID:   "288a21978a6d496b90aefec65844c6ec",
-						},
-					},
-				},
-				Origin:    "LOCAL",
-				TimeFired: time.Now().Format(time.RFC3339),
-				Context: structures.EventContext{
-					ID:       "01JDN9R843GN161T321VYY0FJ7",
-					ParentID: "",
-					UserID:   "288a21978a6d496b90aefec65844c6ec",
-				},
-			},
-		}
-
-	case 3:
-		event = ha.WebhookMessage{
-			ID:   3,
-			Type: "state_changed",
-			Event: structures.EventDetails{
-				EventType: "state_changed",
-				Data: structures.EventData{
-					EntityID: "sensor.sinope_technologies_th1123zb_g2_temperature",
-					OldState: structures.State{},
-					NewState: structures.State{
-						EntityID: "sensor.sinope_technologies_th1123zb_g2_temperature",
-						State:    "21.3",
-						Attributes: map[string]interface{}{
-							"device_class":        "temperature",
-							"friendly_name":       "Sinope Technologies TH1123ZB-G2 Temperature",
-							"state_class":         "measurement",
-							"unit_of_measurement": "°C",
-						},
-						LastChanged: time.Date(2024, 11, 26, 22, 34, 43, 172305000, time.UTC),
-						LastUpdated: time.Date(2024, 11, 26, 22, 34, 43, 172305000, time.UTC),
-						Context: structures.EventContext{
-							ID:       "01JDN9SN345HZCFMAJJG769V8K",
-							ParentID: "",
-							UserID:   "",
-						},
-					},
-				},
-				Origin:    "LOCAL",
-				TimeFired: time.Now().Format(time.RFC3339),
-				Context: structures.EventContext{
-					ID:       "01JDN9SN345HZCFMAJJG769V8K",
-					ParentID: "",
-					UserID:   "",
-				},
-			},
-		}
-
-	case 4:
-		event = ha.WebhookMessage{
-			ID:   4,
-			Type: "Light Warning",
-			Event: structures.EventDetails{
-				EventType: "state_changed",
-				Data: structures.EventData{
-					EntityID: "light.lumi_lumi_switch_b1laus01_light_3",
-					OldState: structures.State{
-						EntityID: "light.lumi_lumi_switch_b1laus01_light_3",
-						State:    "on",
-						Attributes: map[string]interface{}{
-							"friendly_name":         "Kitchen Light",
-							"off_brightness":        nil,
-							"off_with_transition":   false,
-							"supported_color_modes": []string{"onoff"},
-							"supported_features":    8,
-						},
-						LastChanged: time.Date(2024, 11, 26, 22, 33, 57, 907198000, time.UTC),
-						LastUpdated: time.Date(2024, 11, 26, 22, 33, 57, 907198000, time.UTC),
-						Context: structures.EventContext{
-							ID:       "01JDN9R843GN161T321VYY0FJ7",
-							ParentID: "",
-							UserID:   "288a21978a6d496b90aefec65844c6ec",
-						},
-					},
-					NewState: structures.State{
-						EntityID: "light.lumi_lumi_switch_b1laus01_light_3",
-						State:    "on",
-						Attributes: map[string]interface{}{
-							"friendly_name":         "Kitchen Light",
-							"off_brightness":        nil,
-							"off_with_transition":   false,
-							"supported_color_modes": []string{"onoff"},
-							"supported_features":    12,
-						},
-						LastChanged: time.Date(2024, 11, 26, 22, 33, 57, 907198000, time.UTC),
-						LastUpdated: time.Date(2024, 11, 26, 22, 33, 57, 907198000, time.UTC),
-						Context: structures.EventContext{
-							ID:       "01JDN9R843GN161T321VYY0FJ7",
-							ParentID: "",
-							UserID:   "288a21978a6d496b90aefec65844c6ec",
-						},
-					},
-				},
-				Origin:    "LOCAL",
-				TimeFired: time.Now().Format(time.RFC3339),
-				Context: structures.EventContext{
-					ID:       "01JDN9R843GN161T321VYY0FJ7",
-					ParentID: "",
-					UserID:   "288a21978a6d496b90aefec65844c6ec",
-				},
-			},
-		}
-	case 5:
-		event = ha.WebhookMessage{
-			ID:   5,
-			Type: "Light Information",
-			Event: structures.EventDetails{
-				EventType: "state_changed",
-				Data: structures.EventData{
-					EntityID: "light.lumi_lumi_switch_b1laus01_light_3",
-					OldState: structures.State{},
-					NewState: structures.State{
-						EntityID: "light.lumi_lumi_switch_b1laus01_light_3",
-						State:    "on",
-						Attributes: map[string]interface{}{
-							"friendly_name":         "Kitchen Light",
-							"off_brightness":        nil,
-							"off_with_transition":   false,
-							"supported_color_modes": []string{"onoff"},
-							"supported_features":    12,
-						},
-						LastChanged: time.Date(2024, 11, 26, 22, 33, 57, 907198000, time.UTC),
-						LastUpdated: time.Date(2024, 11, 26, 22, 33, 57, 907198000, time.UTC),
-						Context: structures.EventContext{
-							ID:       "01JDN9R843GN161T321VYY0FJ7",
-							ParentID: "",
-							UserID:   "288a21978a6d496b90aefec65844c6ec",
-						},
-					},
-				},
-				Origin:    "LOCAL",
-				TimeFired: time.Now().Format(time.RFC3339),
-				Context: structures.EventContext{
-					ID:       "01JDN9R843GN161T321VYY0FJ7",
-					ParentID: "",
-					UserID:   "288a21978a6d496b90aefec65844c6ec",
-				},
-			},
-		}
-	case 6:
-		event = ha.WebhookMessage{
-			ID:   3,
-			Type: "state_changed",
-			Event: structures.EventDetails{
-				EventType: "state_changed",
-				Data: structures.EventData{
-					EntityID: "battery.sinope_technologies_th1123zb_g2_temperature",
-					OldState: structures.State{},
-					NewState: structures.State{
-						EntityID: "battery.sinope_technologies_th1123zb_g2_temperature",
-						State:    "21.3",
-						Attributes: map[string]interface{}{
-							"device_class":        "temperature",
-							"friendly_name":       "Sinope Technologies TH1123ZB-G2 Temperature",
-							"state_class":         "measurement",
-							"unit_of_measurement": "°C",
-						},
-						LastChanged: time.Date(2024, 11, 26, 22, 34, 43, 172305000, time.UTC),
-						LastUpdated: time.Date(2024, 11, 26, 22, 34, 43, 172305000, time.UTC),
-						Context: structures.EventContext{
-							ID:       "01JDN9SN345HZCFMAJJG769V8K",
-							ParentID: "",
-							UserID:   "",
-						},
-					},
-				},
-				Origin:    "LOCAL",
-				TimeFired: time.Now().Format(time.RFC3339),
-				Context: structures.EventContext{
-					ID:       "01JDN9SN345HZCFMAJJG769V8K",
-					ParentID: "",
-					UserID:   "",
-				},
-			},
-		}
-
-	case 7:
-		event = ha.WebhookMessage{
-			ID:   3,
-			Type: "state_changed",
-			Event: structures.EventDetails{
-				EventType: "state_changed",
-				Data: structures.EventData{
-					EntityID: "motion.sinope_technologies_th1123zb_g2_temperature",
-					OldState: structures.State{},
-					NewState: structures.State{
-						EntityID: "motion.sinope_technologies_th1123zb_g2_temperature",
-						State:    "21.3",
-						Attributes: map[string]interface{}{
-							"device_class":        "temperature",
-							"friendly_name":       "Sinope Technologies TH1123ZB-G2 Temperature",
-							"state_class":         "measurement",
-							"unit_of_measurement": "°C",
-						},
-						LastChanged: time.Date(2024, 11, 26, 22, 34, 43, 172305000, time.UTC),
-						LastUpdated: time.Date(2024, 11, 26, 22, 34, 43, 172305000, time.UTC),
-						Context: structures.EventContext{
-							ID:       "01JDN9SN345HZCFMAJJG769V8K",
-							ParentID: "",
-							UserID:   "",
-						},
-					},
-				},
-				Origin:    "LOCAL",
-				TimeFired: time.Now().Format(time.RFC3339),
-				Context: structures.EventContext{
-					ID:       "01JDN9SN345HZCFMAJJG769V8K",
-					ParentID: "",
-					UserID:   "",
-				},
-			},
-		}
-	case 8:
-		event = ha.WebhookMessage{
-			ID:   3,
-			Type: "state_changed",
-			Event: structures.EventDetails{
-				EventType: "state_changed",
-				Data: structures.EventData{
-					EntityID: "door.sinope_technologies_th1123zb_g2_temperature",
-					OldState: structures.State{},
-					NewState: structures.State{
-						EntityID: "door.sinope_technologies_th1123zb_g2_temperature",
-						State:    "21.3",
-						Attributes: map[string]interface{}{
-							"device_class":        "temperature",
-							"friendly_name":       "Sinope Technologies TH1123ZB-G2 Temperature",
-							"state_class":         "measurement",
-							"unit_of_measurement": "°C",
-						},
-						LastChanged: time.Date(2024, 11, 26, 22, 34, 43, 172305000, time.UTC),
-						LastUpdated: time.Date(2024, 11, 26, 22, 34, 43, 172305000, time.UTC),
-						Context: structures.EventContext{
-							ID:       "01JDN9SN345HZCFMAJJG769V8K",
-							ParentID: "",
-							UserID:   "",
-						},
-					},
-				},
-				Origin:    "LOCAL",
-				TimeFired: time.Now().Format(time.RFC3339),
-				Context: structures.EventContext{
-					ID:       "01JDN9SN345HZCFMAJJG769V8K",
-					ParentID: "",
-					UserID:   "",
-				},
-			},
-		}
-	case 9:
-		event = ha.WebhookMessage{
-			ID:   3,
-			Type: "state_changed",
-			Event: structures.EventDetails{
-				EventType: "state_changed",
-				Data: structures.EventData{
-					EntityID: "smoke.sinope_technologies_th1123zb_g2_temperature",
-					OldState: structures.State{},
-					NewState: structures.State{
-						EntityID: "smoke.sinope_technologies_th1123zb_g2_temperature",
-						State:    "21.3",
-						Attributes: map[string]interface{}{
-							"device_class":        "temperature",
-							"friendly_name":       "Sinope Technologies TH1123ZB-G2 Temperature",
-							"state_class":         "measurement",
-							"unit_of_measurement": "°C",
-						},
-						LastChanged: time.Date(2024, 11, 26, 22, 34, 43, 172305000, time.UTC),
-						LastUpdated: time.Date(2024, 11, 26, 22, 34, 43, 172305000, time.UTC),
-						Context: structures.EventContext{
-							ID:       "01JDN9SN345HZCFMAJJG769V8K",
-							ParentID: "",
-							UserID:   "",
-						},
-					},
-				},
-				Origin:    "LOCAL",
-				TimeFired: time.Now().Format(time.RFC3339),
-				Context: structures.EventContext{
-					ID:       "01JDN9SN345HZCFMAJJG769V8K",
-					ParentID: "",
-					UserID:   "",
-				},
-			},
-		}
-	case 10:
-		event = ha.WebhookMessage{
-			ID:   3,
-			Type: "state_changed",
-			Event: structures.EventDetails{
-				EventType: "state_changed",
-				Data: structures.EventData{
-					EntityID: "water.sinope_technologies_th1123zb_g2_temperature",
-					OldState: structures.State{},
-					NewState: structures.State{
-						EntityID: "water.sinope_technologies_th1123zb_g2_temperature",
-						State:    "21.3",
-						Attributes: map[string]interface{}{
-							"device_class":        "temperature",
-							"friendly_name":       "Sinope Technologies TH1123ZB-G2 Temperature",
-							"state_class":         "measurement",
-							"unit_of_measurement": "°C",
-						},
-						LastChanged: time.Date(2024, 11, 26, 22, 34, 43, 172305000, time.UTC),
-						LastUpdated: time.Date(2024, 11, 26, 22, 34, 43, 172305000, time.UTC),
-						Context: structures.EventContext{
-							ID:       "01JDN9SN345HZCFMAJJG769V8K",
-							ParentID: "",
-							UserID:   "",
-						},
-					},
-				},
-				Origin:    "LOCAL",
-				TimeFired: time.Now().Format(time.RFC3339),
-				Context: structures.EventContext{
-					ID:       "01JDN9SN345HZCFMAJJG769V8K",
-					ParentID: "",
-					UserID:   "",
-				},
-			},
-		}
-	case 11:
-		event = ha.WebhookMessage{
-			ID:   3,
-			Type: "state_changed",
-			Event: structures.EventDetails{
-				EventType: "state_changed",
-				Data: structures.EventData{
-					EntityID: "temperature.sinope_technologies_th1123zb_g2_temperature",
-					OldState: structures.State{},
-					NewState: structures.State{
-						EntityID: "temperature.sinope_technologies_th1123zb_g2_temperature",
-						State:    "21.3",
-						Attributes: map[string]interface{}{
-							"device_class":        "temperature",
-							"friendly_name":       "Sinope Technologies TH1123ZB-G2 Temperature",
-							"state_class":         "measurement",
-							"unit_of_measurement": "°C",
-						},
-						LastChanged: time.Date(2024, 11, 26, 22, 34, 43, 172305000, time.UTC),
-						LastUpdated: time.Date(2024, 11, 26, 22, 34, 43, 172305000, time.UTC),
-						Context: structures.EventContext{
-							ID:       "01JDN9SN345HZCFMAJJG769V8K",
-							ParentID: "",
-							UserID:   "",
-						},
-					},
-				},
-				Origin:    "LOCAL",
-				TimeFired: time.Now().Format(time.RFC3339),
-				Context: structures.EventContext{
-					ID:       "01JDN9SN345HZCFMAJJG769V8K",
-					ParentID: "",
-					UserID:   "",
-				},
-			},
-		}
+	dir := "/app/config/mockhub/mock-events.yaml"
+	data, err := os.ReadFile(dir)
+	if err != nil {
+		panic(err)
 	}
 
-	return event
+	var eventsWrapper EventsWrapper
+	err = yaml.Unmarshal(data, &eventsWrapper)
+	if err != nil {
+		panic(err)
+	}
+
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	randomEvent := eventsWrapper.Events[r.Intn(len(eventsWrapper.Events))]
+
+	now := time.Now().UTC()
+
+	//override TimeFired with the current time
+	//Keep previous format to avoid breaking changes
+	randomEvent.Event.TimeFired = time.Date(
+		now.Year(),
+		now.Month(),
+		now.Day(),
+		now.Hour(),
+		now.Minute(),
+		now.Second(),
+		now.Nanosecond(),
+		time.UTC,
+	).Format("2006-01-02 15:04:05.000000000 MST")
+
+	return randomEvent
 }

--- a/go/common/structures/structures.go
+++ b/go/common/structures/structures.go
@@ -39,39 +39,39 @@ type Announcement struct {
 }
 
 type StateEvent struct {
-	HubID     int       `json:"id"`         // ID of the sender
-	DeviceID  string    `json:"device"`     // ID of the device
-	State     State     `json:"state"`      // The message content
-	TimeStamp time.Time `json:"time_fired"` // Timestamp for when the message was created
+	HubID     int       `json:"id" yaml:"id"`                 // ID of the sender
+	DeviceID  string    `json:"device" yaml:"device"`         // ID of the device
+	State     State     `json:"state" yaml:"state"`           // The message content
+	TimeStamp time.Time `json:"time_fired" yaml:"time_fired"` // Timestamp for when the message was created
 }
 
 type HubLog struct {
-	HubID     string    `json:"id"`
-	Message   string    `json:"message"`
-	TimeStamp time.Time `json:"time_fired"`
+	HubID     string    `json:"id" yaml:"id"`
+	Message   string    `json:"message" yaml:"message"`
+	TimeStamp time.Time `json:"time_fired" yaml:"time_fired"`
 }
 
 type EventDetails struct {
-	EventType string       `json:"event_type"`
-	Data      EventData    `json:"data"`
-	Origin    string       `json:"origin"`
-	TimeFired string       `json:"time_fired"`
-	Context   EventContext `json:"context"`
+	EventType string       `json:"event_type" yaml:"event_type"`
+	Data      EventData    `json:"data" yaml:"data"`
+	Origin    string       `json:"origin" yaml:"origin"`
+	TimeFired string       `json:"time_fired" yaml:"time_fired"`
+	Context   EventContext `json:"context" yaml:"context"`
 }
 
 type EventData struct {
-	EntityID string `json:"entity_id"`
-	OldState State  `json:"old_state"`
-	NewState State  `json:"new_state"`
+	EntityID string `json:"entity_id" yaml:"entity_id"`
+	OldState State  `json:"old_state" yaml:"old_state"`
+	NewState State  `json:"new_state" yaml:"new_state"`
 }
 
 type State struct {
-	EntityID    string                 `json:"entity_id"`
-	State       string                 `json:"state"`
-	Attributes  map[string]interface{} `json:"attributes"`   // Added to capture dynamic attributes
-	LastChanged time.Time              `json:"last_changed"` // Added to capture last changed time
-	LastUpdated time.Time              `json:"last_updated"` // Added to capture last updated time
-	Context     EventContext           `json:"context"`      // Added to include context information
+	EntityID    string                 `json:"entity_id" yaml:"entity_id"`
+	State       string                 `json:"state" yaml:"state"`
+	Attributes  map[string]interface{} `json:"attributes" yaml:"attributes"`     // Added to capture dynamic attributes
+	LastChanged time.Time              `json:"last_changed" yaml:"last_changed"` // Added to capture last changed time
+	LastUpdated time.Time              `json:"last_updated" yaml:"last_updated"` // Added to capture last updated time
+	Context     EventContext           `json:"context" yaml:"context"`           // Added to include context information
 }
 
 // TODO: SHOULD MAKE A GENERIC "EVENT" HA ENTITY STRUCT, SIMILAR TO "State" BUT NOT THE SAME
@@ -79,15 +79,15 @@ type State struct {
 // https://developers.home-assistant.io/docs/dev_101_states/
 // https://developers.home-assistant.io/docs/core/entity/
 type EventContext struct {
-	ID       string `json:"id"`
-	ParentID string `json:"parent_id"`
-	UserID   string `json:"user_id"`
+	ID       string `json:"id" yaml:"id"`
+	ParentID string `json:"parent_id" yaml:"parent_id"`
+	UserID   string `json:"user_id" yaml:"user_id"`
 }
 type Service struct {
-	ServiceID   string                 `json:"service_id"` // Important for service calls
-	Domain      string                 `json:"domain"`
-	Description string                 `json:"description"`
-	ServiceData map[string]interface{} `json:"service_data"`
+	ServiceID   string                 `json:"service_id" yaml:"service_id"` // Important for service calls
+	Domain      string                 `json:"domain" yaml:"domain"`
+	Description string                 `json:"description" yaml:"description"`
+	ServiceData map[string]interface{} `json:"service_data" yaml:"service_data"`
 }
 
 // Automation represents an automation in Home Assistant.
@@ -105,12 +105,12 @@ type HARegistry interface {
 }
 
 type Alert struct {
-	Type      string    `json:"type"`
-	HubIP     string    `json:"hub_ip"`
-	DeviceID  string    `json:"device"`
-	State     string    `json:"state"`
-	Message   string    `json:"message"`
-	TimeStamp time.Time `json:"time_fired"`
+	Type      string    `json:"type" yaml:"type"`
+	HubIP     string    `json:"hub_ip" yaml:"hub_ip"`
+	DeviceID  string    `json:"device" yaml:"device"`
+	State     string    `json:"state" yaml:"state"`
+	Message   string    `json:"message" yaml:"message"`
+	TimeStamp time.Time `json:"time_fired" yaml:"time_fired"`
 }
 
 type TestMongoMessage struct {

--- a/go/hub/ha/ha.go
+++ b/go/hub/ha/ha.go
@@ -23,27 +23,27 @@ type HomeAssistantInstance struct {
 	EntityRegistry interface{}
 }
 type WebhookMessage struct {
-	ID    int                     `json:"id"`
-	Type  string                  `json:"type"`
-	Event structures.EventDetails `json:"event"`
+	ID    int                     `json:"id" yaml:"id"`
+	Type  string                  `json:"type" yaml:"type"`
+	Event structures.EventDetails `json:"event" yaml:"event"`
 }
 
 // ConciseEvent represents a shortened Home Assistant event.
 type ConciseEvent struct {
-	Attributes  ConciseAttributes       `json:"attributes"`
-	Context     structures.EventContext `json:"context"`
-	EntityID    string                  `json:"entity_id"`
-	LastChanged time.Time               `json:"last_changed"`
-	LastUpdated time.Time               `json:"last_updated"`
-	State       string                  `json:"state"`
+	Attributes  ConciseAttributes       `json:"attributes" yaml:"attributes"`
+	Context     structures.EventContext `json:"context" yaml:"context"`
+	EntityID    string                  `json:"entity_id" yaml:"entity_id"`
+	LastChanged time.Time               `json:"last_changed" yaml:"last_changed"`
+	LastUpdated time.Time               `json:"last_updated" yaml:"last_updated"`
+	State       string                  `json:"state" yaml:"state"`
 }
 
 // ConciseAttributes represents attributes field of a ConciseEvent
 type ConciseAttributes struct {
-	DeviceClass       *string     `json:"device_class,omitempty"`
-	FriendlyName      *string     `json:"friendly_name,omitempty"`
-	StateClass        *string     `json:"state_class,omitempty"`
-	SupportedFeatures interface{} `json:"supported_features,omitempty"`
+	DeviceClass       *string     `json:"device_class,omitempty" yaml:"device_class,omitempty"`
+	FriendlyName      *string     `json:"friendly_name,omitempty" yaml:"friendly_name,omitempty"`
+	StateClass        *string     `json:"state_class,omitempty" yaml:"state_class,omitempty"`
+	SupportedFeatures interface{} `json:"supported_features,omitempty" yaml:"supported_features,omitempty"`
 }
 
 // Converts any structures.State struct to a ConciseEvent struct.


### PR DESCRIPTION
Encapsulate mock events into yaml, randomly generated to match an alert type
Fix alert timestamp to represent current time instead of hardcoded
Add events to simulate different alert types:

- AlertTypeLight = "Light"
- AlertTypeSensor = "Sensor"
- AlertTypeClimate = "Climate"
- AlertTypeBatteryLow = "BatteryLow"
- AlertTypeMotion = "Motion"
- AlertTypeDoorOpen = "DoorOpen"
- AlertTypeSmoke = "Smoke"
- AlertTypeWater = "Water"
- AlertTypeTemperature = "Temperature"
- AlertTypeUnknown = "Unknown

Closes #662 